### PR TITLE
Harden cmd control flow

### DIFF
--- a/plugin.video.stream-cinema/.gitignore
+++ b/plugin.video.stream-cinema/.gitignore
@@ -7,3 +7,4 @@
 .idea
 *.pyc
 .DS_Store
+__pycache__/

--- a/plugin.video.stream-cinema/README.md
+++ b/plugin.video.stream-cinema/README.md
@@ -1,0 +1,18 @@
+# Stream Cinema
+
+This plugin includes optional remote-control features. Remote commands can be sent using the `cmd://` URL scheme or over the WebSocket service.
+
+Only a small set of Kodi built-in commands is allowed. When a `cmd://` link is processed the command is validated and anything outside the whitelist is ignored and logged. Allowed command prefixes are:
+
+- `Action(`
+- `PlayMedia(`
+- `RunPlugin(`
+- `Container.Update`
+- `Container.Refresh`
+- `ActivateWindow(`
+- `Addon.OpenSettings(`
+- `SetFocus(`
+- `UpdateAddonRepos`
+- `UpdateLocalAddons`
+
+Any other command will be skipped for safety.

--- a/plugin.video.stream-cinema/resources/lib/streamcinema.py
+++ b/plugin.video.stream-cinema/resources/lib/streamcinema.py
@@ -14,7 +14,7 @@ from resources.lib.debug import performance
 from resources.lib.intro import intro
 from resources.lib.kodiutils import params, container_refresh, urlencode, container_update, create_plugin_url, \
     exec_build_in, download, get_setting, update_addon, set_setting_as_bool, notify, get_setting_as_bool
-from resources.lib.common.logger import info, debug
+from resources.lib.common.logger import info, debug, warning
 from resources.lib.common.lists import List, SCKODIItem
 from resources.lib.constants import SORT_METHODS, SC, GUI, ADDON_ID
 from resources.lib.api.sc import Sc
@@ -26,6 +26,20 @@ from resources.lib.language import Strings
 from resources.lib.params import params
 from resources.lib.services.next_episodes import NextEp
 from resources.lib.system import SYSTEM_LANG_CODE
+
+
+ALLOWED_CMD_PREFIXES = [
+    'Action(',
+    'PlayMedia(',
+    'RunPlugin(',
+    'Container.Update',
+    'Container.Refresh',
+    'ActivateWindow(',
+    'Addon.OpenSettings(',
+    'SetFocus(',
+    'UpdateAddonRepos',
+    'UpdateLocalAddons',
+]
 
 
 class Scinema:
@@ -244,9 +258,12 @@ class Scinema:
         url = self.args.get('url')
         if url.startswith('cmd://'):
             cmd = url[6:]
-            info('CMD: {}'.format(cmd))
-            exec_build_in(cmd)
-            self.send_end = True
+            if any(cmd.startswith(p) for p in ALLOWED_CMD_PREFIXES):
+                info('CMD: {}'.format(cmd))
+                exec_build_in(cmd)
+                self.send_end = True
+            else:
+                warning('Blocked CMD attempt: {}'.format(cmd))
             # self.succeeded = True
             # self.end_of_directory()
 

--- a/plugin.video.stream-cinema/tests/test_cmd_whitelist.py
+++ b/plugin.video.stream-cinema/tests/test_cmd_whitelist.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import patch
+
+# Import environment setup from other tests
+import tests.test_sc_api  # noqa: F401
+import sys
+
+# Prepare argv for modules that read sys.argv at import time
+sys.argv = ['plugin', '1', '']
+# Extend fake xbmcgui module with attributes required for import
+fake_xbmcgui = sys.modules.get('xbmcgui')
+fake_xbmcgui.NOTIFICATION_INFO = 0
+fake_xbmcgui.INPUT_ALPHANUM = 0
+fake_xbmcgui.INPUT_TYPE_TEXT = 0
+fake_xbmcgui.INPUT_NUMERIC = 0
+fake_xbmcgui.Dialog = type('Dialog', (), {})
+fake_xbmcgui.DialogProgressBG = type('DialogProgressBG', (), {})
+fake_xbmcgui.DialogProgress = type('DialogProgress', (), {})
+fake_xbmcgui.ListItem = type('ListItem', (), {})
+
+fake_xbmc = sys.modules.get('xbmc')
+fake_xbmc.Player = type('Player', (), {})
+
+from resources.lib.streamcinema import Scinema
+from resources.lib.constants import SC
+
+class CmdWhitelistTest(unittest.TestCase):
+    def setUp(self):
+        self.sc = Scinema()
+        self.sc.args = {}
+
+    def test_allowed_command_executes(self):
+        self.sc.args = {SC.ITEM_ACTION: SC.ACTION_CMD, 'url': 'cmd://Action(Back)'}
+        with patch('resources.lib.streamcinema.exec_build_in') as mock_exec:
+            self.sc.action_cmd()
+            mock_exec.assert_called_once_with('Action(Back)')
+            self.assertTrue(self.sc.send_end)
+
+    def test_blocked_command_ignored(self):
+        self.sc.args = {SC.ITEM_ACTION: SC.ACTION_CMD, 'url': 'cmd://System.Exec(bad)'}
+        with patch('resources.lib.streamcinema.exec_build_in') as mock_exec, \
+             patch('resources.lib.streamcinema.warning') as mock_warn:
+            self.sc.action_cmd()
+            mock_exec.assert_not_called()
+            mock_warn.assert_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a whitelist for cmd:// built-ins
- log and ignore attempts to run other commands
- document remaining remote-command interface
- test allowed vs blocked commands

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_6847413eacc8832c80775cad1aa822d3